### PR TITLE
戦績入力機能の作成

### DIFF
--- a/app/controllers/battle_records_controller.rb
+++ b/app/controllers/battle_records_controller.rb
@@ -1,0 +1,5 @@
+class BattleRecordsController < ApplicationController
+  def new
+    render "battle_records/#{params[:name]}"
+  end
+end

--- a/app/models/battle_record.rb
+++ b/app/models/battle_record.rb
@@ -1,0 +1,6 @@
+class BattleRecord < ApplicationRecord
+  belongs_to :user
+  belongs_to :winning_eleven
+
+  validates :rate, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :battle_records, dependent: :destroy
+  has_many :winning_elevens, through: :battle_records
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/winning_eleven.rb
+++ b/app/models/winning_eleven.rb
@@ -1,0 +1,7 @@
+class WinningEleven < ApplicationRecord
+  has_many :battle_records, dependent: :destroy
+  has_many :users, through: :battle_records
+
+  validates :series_status, presence: true
+  validates :title, presence: true
+end

--- a/app/views/battle_records/current.html.erb
+++ b/app/views/battle_records/current.html.erb
@@ -1,0 +1,17 @@
+<div class="container">
+    <div class="row">
+        <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+            <%= form_with model: @battle_record, local: true do |f| %>
+                <div class="form-group">
+                    <%= f.label :rate %>
+                    <%= f.text_field :rate, class: 'form-control' %>
+                </div>
+                <div class="form-group">
+                    <%= f.label :win_rate %>
+                    <%= f.text_field :win_rate, class: 'form-control' %>
+                </div>
+                <%= f.submit (t 'defaults.compare'), class: 'btn btn-primary' %>
+            <% end %>
+        </div>
+    </div>
+</div>

--- a/app/views/battle_records/past.html.erb
+++ b/app/views/battle_records/past.html.erb
@@ -1,0 +1,17 @@
+<div class="container">
+    <div class="row">
+        <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+            <%= form_with model: @battle_record, local: true do |f| %>
+                <div class="form-group">
+                    <%= f.label :rate %>
+                    <%= f.text_field :rate, class: 'form-control' %>
+                </div>
+                <div class="form-group">
+                    <%= f.label :win_rate %>
+                    <%= f.text_field :win_rate, class: 'form-control' %>
+                </div>
+                <%= f.submit (t 'defaults.register'), class: 'btn btn-primary' %>
+            <% end %>
+        </div>
+    </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <div class="text-center">
     <div class="d-inline-flex flex-column">
-        <%=link_to '過去作の戦績を入力', '#', class: 'btn btn-primary mb-4' %>
-        <%= link_to '現在の戦績を入力', '#', class: 'btn btn-primary' %>
+        <%=link_to '過去作の戦績を入力', {controller: "battle_records", action: "new", name: "past"}, class: 'btn btn-primary mb-4' %>
+        <%= link_to '現在の戦績を入力', {controller: "battle_records", action: "new", name: "current"}, class: 'btn btn-primary' %>
     </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,7 @@ ja:
     login: 'ログイン'
     register: '登録'
     logout: 'ログアウト'
+    compare: '比較'
   users:
     new:
       title: '新規登録'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
 
   get 'mypage', to: 'users#show'
   resources :users, only: %i[new create]
+
+  get 'battle_records/:name', to: 'battle_records#new'
 end

--- a/db/migrate/20210625080003_create_winning_elevens.rb
+++ b/db/migrate/20210625080003_create_winning_elevens.rb
@@ -1,0 +1,10 @@
+class CreateWinningElevens < ActiveRecord::Migration[6.0]
+  def change
+    create_table :winning_elevens do |t|
+      t.integer :series_status, default: 0, null: false
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210625083853_create_battle_records.rb
+++ b/db/migrate/20210625083853_create_battle_records.rb
@@ -1,0 +1,12 @@
+class CreateBattleRecords < ActiveRecord::Migration[6.0]
+  def change
+    create_table :battle_records do |t|
+      t.integer :rate, null:false
+      t.float :win_rate
+      t.references :user, null: false, foreign_key: true
+      t.references :winning_eleven, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_25_082413) do
+ActiveRecord::Schema.define(version: 2021_06_25_083853) do
+
+  create_table "battle_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "rate", null: false
+    t.float "win_rate"
+    t.bigint "user_id", null: false
+    t.bigint "winning_eleven_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_battle_records_on_user_id"
+    t.index ["winning_eleven_id"], name: "index_battle_records_on_winning_eleven_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", null: false
@@ -21,4 +32,13 @@ ActiveRecord::Schema.define(version: 2021_05_25_082413) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "winning_elevens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "series_status", default: 0, null: false
+    t.string "title", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "battle_records", "users"
+  add_foreign_key "battle_records", "winning_elevens"
 end


### PR DESCRIPTION
## 概要

Battle_recordモデルとWinning_elevenモデルを作成しました。
マイページから過去作の戦績入力ページと現在の戦績入力ページに遷移できるようにしました。

## コメント

1つのアクションで複数のビューを切り替えて表示するようにしています。