### PR TITLE
戦績一覧機能の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,6 @@ gem 'cancancan'
 
 gem 'seed-fu'
 
-gem 'chartkick'
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     cancancan (3.3.0)
-    chartkick (4.0.5)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -289,7 +288,6 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   cancancan
-  chartkick
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)

--- a/app/controllers/battle_records_controller.rb
+++ b/app/controllers/battle_records_controller.rb
@@ -1,4 +1,9 @@
 class BattleRecordsController < ApplicationController
+  def index
+    @winning_elevens = WinningEleven.where(series_status: 'past').order(:title)
+    @battle_records = @winning_elevens.map { |winning_eleven| current_user.battle_records.where(winning_eleven_id: winning_eleven).order(created_at: :desc).limit(1) }.flatten
+  end
+
   def new
     @battle_record = BattleRecord.new
     render "battle_records/#{params[:name]}"
@@ -14,6 +19,13 @@ class BattleRecordsController < ApplicationController
       @monthly.save
     end
     redirect_to mypage_path
+  end
+
+  def destroy
+    @battle_record = BattleRecord.find(params[:id])
+    @battle_record = current_user.battle_records.where(winning_eleven_id: @battle_record.winning_eleven_id)
+    @battle_record.destroy_all
+    redirect_to battle_records_path
   end
 
   private

--- a/app/controllers/battle_records_controller.rb
+++ b/app/controllers/battle_records_controller.rb
@@ -7,6 +7,12 @@ class BattleRecordsController < ApplicationController
   def create
     @battle_record = current_user.battle_records.build(battle_record_params)
     @battle_record.save!
+    @winning_eleven = @battle_record.winning_eleven
+    if @winning_eleven.series_status == 'current'
+      @monthly = @battle_record.monthlies.build(monthly_battle_record_params)
+      @monthly.month = Date.today.month
+      @monthly.save
+    end
     redirect_to mypage_path
   end
 
@@ -14,5 +20,9 @@ class BattleRecordsController < ApplicationController
 
   def battle_record_params
     params.require(:battle_record).permit(:rate, :win_rate, :winning_eleven_id)
+  end
+
+  def monthly_battle_record_params
+    params.require(:battle_record).permit(:rate, :win_rate)
   end
 end

--- a/app/controllers/monthlies_controller.rb
+++ b/app/controllers/monthlies_controller.rb
@@ -2,6 +2,7 @@ class MonthliesController < ApplicationController
   def index
     @winning_eleven = WinningEleven.find_by(title: params[:label])
     @battle_record = current_user.battle_records.where(winning_eleven_id: @winning_eleven)
-    @data = @battle_record.joins(:monthlies)
+    @month = Monthly.where(battle_record_id: @battle_record)
+    @data = @month.distinct.pluck(:month)
   end
 end

--- a/app/controllers/monthlies_controller.rb
+++ b/app/controllers/monthlies_controller.rb
@@ -1,0 +1,7 @@
+class MonthliesController < ApplicationController
+  def index
+    @winning_eleven = WinningEleven.find_by(title: params[:label])
+    @battle_record = current_user.battle_records.where(winning_eleven_id: @winning_eleven)
+    @data = @battle_record.joins(:monthlies)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,16 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def show
-    @battle_record = current_user.battle_records
-    @data = @battle_record.joins(:winning_eleven).order(:title)
+    @battle_record = current_user.battle_records.joins(:winning_eleven)
+    @data = @battle_record.order(:title).distinct.pluck(:title)
+    @rate = @data.map do |d|
+      @winning_eleven = WinningEleven.find_by(title: d)
+      @battle_record.where(winning_eleven_id: @winning_eleven).order(created_at: :desc).limit(1).pluck(:rate)
+    end
+    @win_rate = @data.map do |d|
+      @winning_eleven = WinningEleven.find_by(title: d)
+      @battle_record.where(winning_eleven_id: @winning_eleven).order(created_at: :desc).limit(1).pluck(:win_rate)
+    end
   end
 
   def new

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,6 +1,5 @@
 import 'bootstrap';
 import '../stylesheets/application';
-import 'chartkick/highcharts'
 
 // This file is automatically compiled by Webpack, along with any other files
 // present in this directory. You're encouraged to place your actual application logic in

--- a/app/models/battle_record.rb
+++ b/app/models/battle_record.rb
@@ -1,6 +1,7 @@
 class BattleRecord < ApplicationRecord
   belongs_to :user
   belongs_to :winning_eleven
+  has_many :monthlies, dependent: :destroy
 
   validates :rate, numericality: { less_than_or_equal_to: 9999 }
   validates :win_rate, numericality: { less_than_or_equal_to: 100 }, allow_blank: true, format: { with: /\A[0-9]+\.[0-9]\z/ }

--- a/app/models/battle_record.rb
+++ b/app/models/battle_record.rb
@@ -12,7 +12,8 @@ class BattleRecord < ApplicationRecord
   end
 
   def past?
-    return unless winning_eleven_id.present?
+    current_user = BattleRecord.find_by(user_id: user_id, winning_eleven_id: winning_eleven_id)
+    return unless current_user.present? && winning_eleven_id.present?
 
     winning_eleven.series_status == 'past'
   end

--- a/app/models/monthly.rb
+++ b/app/models/monthly.rb
@@ -1,0 +1,3 @@
+class Monthly < ApplicationRecord
+  belongs_to :battle_record
+end

--- a/app/views/battle_records/current.html.erb
+++ b/app/views/battle_records/current.html.erb
@@ -3,7 +3,7 @@
         <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
             <%= form_with model: @battle_record, local: true do |f| %>
                 <div class="form-group d-inline-flex flex-column">
-                    <%= f.label :title %>
+                    <%= f.label :title, WinningEleven.human_attribute_name(:title) %>
                     <%= f.collection_select :winning_eleven_id, WinningEleven.current, :id, :title %>
                 </div>
                 <div class="form-group">

--- a/app/views/battle_records/index.html.erb
+++ b/app/views/battle_records/index.html.erb
@@ -1,0 +1,20 @@
+<table>
+    <thead>
+        <tr>
+            <th><%= WinningEleven.human_attribute_name(:title) %></th>
+            <th><%= BattleRecord.human_attribute_name(:rate) %></th>
+            <th><%= BattleRecord.human_attribute_name(:win_rate) %></th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @battle_records.each do |battle_record| %>
+            <% winning_eleven = WinningEleven.find(battle_record.winning_eleven_id) %>
+            <tr>
+                <td><%= winning_eleven.title %></td>
+                <td><%= battle_record.rate %></td>
+                <td><%= battle_record.win_rate %></td>
+                <td><%= link_to '削除', battle_record, method: :delete, data: { confirm: "#{winning_eleven.title}を削除します。よろしいですか？"}, class: 'btn btn-danger' %></td>
+            </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/app/views/battle_records/past.html.erb
+++ b/app/views/battle_records/past.html.erb
@@ -3,7 +3,7 @@
         <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
             <%= form_with model: @battle_record, local: true do |f| %>
                 <div class="form-group d-inline-flex flex-column">
-                    <%= f.label :title %>
+                    <%= f.label :title, WinningEleven.human_attribute_name(:title) %>
                     <%= f.collection_select :winning_eleven_id, WinningEleven.past, :id, :title, prompt: "選択してください" %>
                 </div>
                 <div class="form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js"></script>
   </head>
 
   <body>

--- a/app/views/monthlies/index.html.erb
+++ b/app/views/monthlies/index.html.erb
@@ -1,0 +1,48 @@
+<div style="margin: 0 auto; width: 500px">
+    <canvas id="myChart" height="300"></canvas>
+    <canvas id="myChart1" height="300"></canvas>
+</div>
+<script>
+var ctx = document.getElementById('myChart').getContext('2d');
+var myChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: <%= @data.distinct.pluck(:month).map {|a|a.to_s + '月'}.to_json.html_safe %>,
+        datasets: [{
+            label: 'Rate',
+            data: <%= @data.order(created_at: :desc).pluck(:rate) %>
+        }]
+    },
+    options: {
+        scales: {
+            yAxes: [{
+                ticks: {
+                    beginAtZero: true
+                }
+            }]
+        }
+    }
+});
+
+var ctx1 = document.getElementById('myChart1').getContext('2d');
+var myChart1 = new Chart(ctx1, {
+    type: 'bar',
+    data: {
+        labels: <%= @data.distinct.pluck(:month).map {|a|a.to_s + '月'}.to_json.html_safe %>,
+        datasets: [{
+            label: '勝率',
+            data: <%= @data.order(created_at: :desc).pluck(:win_rate) %>
+        }]
+    },
+    options: {
+        scales: {
+            yAxes: [{
+                ticks: {
+                    min: 0,
+                    max: 100
+                }
+            }]
+        }
+    }
+});
+</script>

--- a/app/views/monthlies/index.html.erb
+++ b/app/views/monthlies/index.html.erb
@@ -7,10 +7,10 @@ var ctx = document.getElementById('myChart').getContext('2d');
 var myChart = new Chart(ctx, {
     type: 'bar',
     data: {
-        labels: <%= @data.distinct.pluck(:month).map {|a|a.to_s + '月'}.to_json.html_safe %>,
+        labels: <%= @data.map {|d|d.to_s + '月'}.to_json.html_safe %>,
         datasets: [{
             label: 'Rate',
-            data: <%= @data.order(created_at: :desc).pluck(:rate) %>
+            data: <%= @data.map {|d|@month.where(month: d).order(created_at: :desc).limit(1).pluck(:rate)}.flatten %>
         }]
     },
     options: {
@@ -28,10 +28,10 @@ var ctx1 = document.getElementById('myChart1').getContext('2d');
 var myChart1 = new Chart(ctx1, {
     type: 'bar',
     data: {
-        labels: <%= @data.distinct.pluck(:month).map {|a|a.to_s + '月'}.to_json.html_safe %>,
+        labels: <%= @data.map {|d|d.to_s + '月'}.to_json.html_safe %>,
         datasets: [{
             label: '勝率',
-            data: <%= @data.order(created_at: :desc).pluck(:win_rate) %>
+            data: <%= @data.map {|d|@month.where(month: d).order(created_at: :desc).limit(1).pluck(:win_rate)}.flatten %>
         }]
     },
     options: {

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,9 @@
         <div class="collapse navbar-collapse">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item">
+                    <%= link_to t('battle_records.index.title'), battle_records_path, class: 'nav-link' %>
+                </li>
+                <li class="nav-item">
                     <%= link_to (t 'defaults.logout'), logout_path, class: 'nav-link', method: :delete %>
                 </li>
             </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,10 +8,10 @@ var ctx = canvas.getContext('2d');
 var myChart = new Chart(ctx, {
     type: 'bar',
     data: {
-        labels: <%= @data.distinct.pluck(:title).to_json.html_safe %>,
+        labels: <%= @data.to_json.html_safe %>,
         datasets: [{
             label: 'Rate',
-            data: <%= @data.order(created_at: :desc).pluck(:rate) %>
+            data: <%= @rate.flatten %>
         }]
     },
     options: {
@@ -39,10 +39,10 @@ var ctx1 = canvas1.getContext('2d');
 var myChart1 = new Chart(ctx1, {
     type: 'bar',
     data: {
-        labels: <%= @data.distinct.pluck(:title).to_json.html_safe %>,
+        labels: <%= @data.to_json.html_safe %>,
         datasets: [{
             label: '勝率',
-            data: <%= @data.order(created_at: :desc).pluck(:win_rate) %>
+            data: <%= @win_rate.flatten %>
         }]
     },
     options: {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,10 +1,6 @@
-<div class="text-center">
-    <% if @data.present? %>
-        <%= column_chart @data.pluck(:title, :rate), library: {title: {text: 'Rate'}} %>
-        <%= column_chart @data.pluck(:title, :win_rate), max: 100, suffix: "%", library: {title: {text: '勝率'}, plotOptions: {column: {dataLabels: {enabled: true, format: '{point.y:.1f}%'}}}} %>
-    <% else %>
-        <p><%= t('.no_result') %></p>
-    <% end %>
+<div class="text-center mx-1">
+    <%= column_chart @data.pluck(:title, :rate), library: {title: {text: 'Rate'}} %>
+    <%= column_chart @data.pluck(:title, :win_rate), max: 100, suffix: "%", library: {title: {text: '勝率'}, plotOptions: {column: {dataLabels: {enabled: true, format: '{point.y:.1f}%'}}}} %>
     <div class="d-inline-flex flex-column">
         <%=link_to '過去作の戦績を入力', {controller: "battle_records", action: "new", name: "past"}, class: 'btn btn-primary mb-4' %>
         <%= link_to '現在の戦績を入力', {controller: "battle_records", action: "new", name: "current"}, class: 'btn btn-primary' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,8 +1,74 @@
-<div class="text-center mx-1">
-    <%= column_chart @data.pluck(:title, :rate), library: {title: {text: 'Rate'}} %>
-    <%= column_chart @data.pluck(:title, :win_rate), max: 100, suffix: "%", library: {title: {text: '勝率'}, plotOptions: {column: {dataLabels: {enabled: true, format: '{point.y:.1f}%'}}}} %>
+<div style="margin: 0 auto; width: 500px">
+    <canvas id="myChart" height="300"></canvas>
+    <canvas id="myChart1" height="300"></canvas>
+</div>
+<script>
+var canvas = document.getElementById('myChart');
+var ctx = canvas.getContext('2d');
+var myChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: <%= @data.distinct.pluck(:title).to_json.html_safe %>,
+        datasets: [{
+            label: 'Rate',
+            data: <%= @data.order(created_at: :desc).pluck(:rate) %>
+        }]
+    },
+    options: {
+        scales: {
+            yAxes: [{
+                ticks: {
+                    beginAtZero: true
+                }
+            }]
+        }
+    }
+});
+canvas.onclick = function(evt) {
+    var activePoints = myChart.getElementsAtEvent(evt);
+    if (activePoints[0]) {
+        var chartData = activePoints[0]['_chart'].config.data;
+        var idx = activePoints[0]['_index'];
+        var label = chartData.labels[idx];
+        location.href = 'monthlies?label=' + label;
+    }
+};
+
+var canvas1 = document.getElementById('myChart1');
+var ctx1 = canvas1.getContext('2d');
+var myChart1 = new Chart(ctx1, {
+    type: 'bar',
+    data: {
+        labels: <%= @data.distinct.pluck(:title).to_json.html_safe %>,
+        datasets: [{
+            label: '勝率',
+            data: <%= @data.order(created_at: :desc).pluck(:win_rate) %>
+        }]
+    },
+    options: {
+        scales: {
+            yAxes: [{
+                ticks: {
+                    min: 0,
+                    max: 100
+                }
+            }]
+        }
+    }
+});
+canvas1.onclick = function(evt) {
+    var activePoints = myChart1.getElementsAtEvent(evt);
+    if (activePoints[0]) {
+        var chartData1 = activePoints[0]['_chart'].config.data;
+        var idx1 = activePoints[0]['_index'];
+        var label1 = chartData1.labels[idx1];
+        location.href = 'monthlies?label=' + label1;
+    }
+};
+</script>
+<div class="text-center">
     <div class="d-inline-flex flex-column">
-        <%=link_to '過去作の戦績を入力', {controller: "battle_records", action: "new", name: "past"}, class: 'btn btn-primary mb-4' %>
+        <%= link_to '過去作の戦績を入力', {controller: "battle_records", action: "new", name: "past"}, class: 'btn btn-primary mb-4' %>
         <%= link_to '現在の戦績を入力', {controller: "battle_records", action: "new", name: "current"}, class: 'btn btn-primary' %>
     </div>
 </div>

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,0 +1,8 @@
+Chartkick.options = {
+    empty: "データがありません",
+    library: {
+        xAxis: {
+            width: "400px"
+        }
+    }
+}

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,8 +1,0 @@
-Chartkick.options = {
-    empty: "データがありません",
-    library: {
-        xAxis: {
-            width: "400px"
-        }
-    }
-}

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,5 +9,6 @@ ja:
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
       battle_record:
-        title: 'タイトル'
         win_rate: '勝率' 
+      winning_eleven:
+        title: 'タイトル'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,3 +13,6 @@ ja:
       title: 'ログイン'
       to_register_page: '登録ページへ'
       password_forget: 'パスワードをお忘れの方はこちら'
+  battle_records:
+    index:
+      title: '戦績一覧'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,8 +5,6 @@ ja:
     logout: 'ログアウト'
     compare: '比較'
   users:
-    show:
-      no_result: '戦績が登録されていません'
     new:
       title: '新規登録'
       to_login_page: 'ログインページへ'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
 
   get 'battle_records/:name', to: 'battle_records#new'
   resources :battle_records, only: %i[create]
+
+  resources :monthlies, only: %i[index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
 
   get 'battle_records/:name', to: 'battle_records#new'
-  resources :battle_records, only: %i[create]
+  resources :battle_records, only: %i[index create destroy]
 
   resources :monthlies, only: %i[index]
 end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,12 +1,12 @@
 const { environment } = require('@rails/webpacker')
 
 const webpack = require('webpack')
-environment.plugins.prepend(
-    'Provide',
+
+environment.plugins.prepend('Provide',
     new webpack.ProvidePlugin({
-        $: 'jquery',
-        jQuery: 'jquery',
-        Popper: 'popper.js'
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery',
+        Popper: ['popper.js', 'default']
     })
 )
 

--- a/db/migrate/20210720061141_create_monthlies.rb
+++ b/db/migrate/20210720061141_create_monthlies.rb
@@ -1,0 +1,12 @@
+class CreateMonthlies < ActiveRecord::Migration[6.0]
+  def change
+    create_table :monthlies do |t|
+      t.integer :month, null: false
+      t.integer :rate, null: false
+      t.float :win_rate
+      t.references :battle_record, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_052136) do
+ActiveRecord::Schema.define(version: 2021_07_20_061141) do
 
   create_table "battle_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "rate", null: false
@@ -21,6 +21,16 @@ ActiveRecord::Schema.define(version: 2021_06_30_052136) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_battle_records_on_user_id"
     t.index ["winning_eleven_id"], name: "index_battle_records_on_winning_eleven_id"
+  end
+
+  create_table "monthlies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "month", null: false
+    t.integer "rate", null: false
+    t.float "win_rate"
+    t.bigint "battle_record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["battle_record_id"], name: "index_monthlies_on_battle_record_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -42,4 +52,5 @@ ActiveRecord::Schema.define(version: 2021_06_30_052136) do
 
   add_foreign_key "battle_records", "users"
   add_foreign_key "battle_records", "winning_elevens"
+  add_foreign_key "monthlies", "battle_records"
 end

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "bootstrap": "4.5.3",
-    "chartkick": "^4.0.5",
-    "highcharts": "^9.1.2",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,25 +1899,6 @@ chalk@^2.0, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chart.js@>=3.0.2:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.4.1.tgz#ff3b2b2a04a37b83618b4a6399a5f87ccc0f1e8a"
-  integrity sha512-0R4mL7WiBcYoazIhrzSYnWcOw6RmrRn7Q4nKZNsBQZCBrlkZKodQbfeojCCo8eETPRCs1ZNTsAcZhIfyhyP61g==
-
-chartjs-adapter-date-fns@>=2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-2.0.0.tgz#5e53b2f660b993698f936f509c86dddf9ed44c6b"
-  integrity sha512-rmZINGLe+9IiiEB0kb57vH3UugAtYw33anRiw5kS2Tu87agpetDDoouquycWc9pRsKtQo5j+vLsYHyr8etAvFw==
-
-chartkick@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-4.0.5.tgz#310a60c931e8ceedc39adee2ef8e9d1e474cb0e6"
-  integrity sha512-xKak4Fsgfvp1hj/LykRKkniDMaZASx2A4TdVc/sfsiNFFNf1m+D7PGwP1vgj1UsbsCjOCSfGWWyJpOYxkUCBug==
-  optionalDependencies:
-    chart.js ">=3.0.2"
-    chartjs-adapter-date-fns ">=2.0.0"
-    date-fns ">=2.0.0"
-
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -2506,11 +2487,6 @@ dashdash@^1.12.0:
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
-
-date-fns@>=2.0.0:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
-  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -3524,11 +3500,6 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
-
-highcharts@^9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.1.2.tgz#c9b15390a10acb274a941d2aa5bc05c0889646d9"
-  integrity sha512-RwCnJnxAUCGG4R/WDG+QP/4VJNtOpkQTkXcuf58DjDvm9ZILplSMdZvrbMRC9Y9ecuJQCjjZsiifvyS5E2IBvQ==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## 概要

monthliesテーブルを作成し、月別に戦績を保存できるようにしました。
chartkickではグラフをクリックして画面遷移することができなかったため、Chart.jsに変更しました。
ヘッダーから戦績一覧ページに遷移できるようにしました。
戦績一覧ページから過去作の戦績を削除できるようにしました。

## コメント

クエリパラメータを使用してコントローラーに変数を渡しています。